### PR TITLE
Do not send library name and version in the context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Version 0.8.1 (TBD)
+================================
+
+* [REMOVED](https://github.com/circleci/analytics-clj/pull/1): Do not send library name and version in the context
+
 Version 0.8.0 (January 27, 2019)
 ================================
 

--- a/src/circleci/analytics_clj/common.clj
+++ b/src/circleci/analytics_clj/common.clj
@@ -2,9 +2,6 @@
   (:require [circleci.analytics-clj.external :refer :all]
             [circleci.analytics-clj.utils :refer [string-keys]]))
 
-(def ^:private ctx {"library" {"name" "analytics-clj"
-                               "version" "0.8.0"}})
-
 (defn common-fields
   "The `MessageBuilder` interface has a set of fields common to all messages.
 
@@ -22,7 +19,8 @@
               (integration-options* message-builder integration (string-keys options))))]
 
     (doto message-builder
-      (context* (merge ctx (string-keys context)))
+      (cond-> (not (nil? context))
+        (context* (string-keys context)))
 
       (cond-> (not (nil? anonymous-id))
         (anonymous-id* anonymous-id))

--- a/test/circleci/analytics_clj/core_test.clj
+++ b/test/circleci/analytics_clj/core_test.clj
@@ -66,11 +66,11 @@
       (is (= "Amplitude" (-> e/enable-integration* bond/calls first :args second)))
       (is (= false (-> e/enable-integration* bond/calls first :args (nth 2))))))
 
-  (testing "custom context is merged with library context"
+  (testing "custom context"
     (bond/with-spy [e/context*]
       (a/track analytics "1234" "signup" {"company" "Acme Inc."} {:context {:language "en-us"}})
       (is (= 1 (-> e/context* bond/calls count)))
-      (is (= #{"library" "language"} (-> e/context* bond/calls first :args second keys set)))))
+      (is (= #{"language"} (-> e/context* bond/calls first :args second keys set)))))
 
   (testing "integration options"
     (bond/with-spy [e/integration-options*]


### PR DESCRIPTION
This PR _stops_ `analytics-clj` from sending it's own version number to Segment. Thus the Segment.io panel will show the java version, from which we include in `project.clj`.

The pros and cons of sending our own version...

PRO - we can tell which version of analytics-clj is sending events
CON - we don't get the _Pretty Print_ feature in Segment's debugging console