### PR TITLE
Updated a require to a :require

### DIFF
--- a/src/circleci/analytics_clj/utils.clj
+++ b/src/circleci/analytics_clj/utils.clj
@@ -1,5 +1,5 @@
 (ns circleci.analytics-clj.utils
-  (require [clojure.walk :as walk]))
+  (:require [clojure.walk :as walk]))
 
 (defn string-keys
   "Transform all map keys from keywords to strings while preserving namespacing (unlike clojure.walk/stringify-keys)."


### PR DESCRIPTION
Currently, analytics-clj `0.4.0` is not compatible with clojure `1.9.0-alpha14` because of this `require` which needs to be a `:require`

this is a fix so we can bump the version and have a clj-1.9 compatible version