### PR TITLE
add a CI workflow to check for ancient dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,22 @@ jobs:
           paths:
             - "~/.m2"
 
+  ancient:
+    <<: *defaults
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v1-m2-{{ .Branch }}-{{ checksum "project.clj" }}
+
+      - run: lein ancient :all
+
+      - save_cache:
+          key: v1-m2-{{ .Branch }}-{{ checksum "project.clj" }}
+          paths:
+            - "~/.m2"
+
 workflows:
   version: 2
   build_and_test:
@@ -48,3 +64,13 @@ workflows:
       - test:
           requires:
             - build
+  monthly_deps_check:
+    jobs:
+      - ancient
+    triggers:
+      - schedule:
+          # At 11:43 on day-of-month 19
+          cron: "43 11 19 * *"
+          filters:
+            branches:
+              only: master

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [com.segment.analytics.java/analytics "2.1.1"]]
   :profiles {:dev {:dependencies [[bond "0.2.6"]]}}
-  :plugins [[lein-codox "0.10.7"]]
+  :plugins [[lein-ancient "0.6.15"]
+            [lein-codox "0.10.7"]]
   :codox {:output-path "docs"
           :namespaces [circleci.analytics-clj.core]})


### PR DESCRIPTION
This will be a monthly scheduled workflow to ensure that library dependencies are kept up-to-date.