### PR TITLE
Update CODEOWNERS with a more relevant team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Placeholder CODEOWNERS file as this repo did not have one
 # Please make a PR adding the correct owner or request that this repo be archived
-* @circleci/default-security-operations
+* @circleci/backplane


### PR DESCRIPTION
Folks on the Backplane team has more Clojure expertise than the current "owner of last resort".