### PR TITLE
Remove `lein-ancient` plugin and periodic CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,22 +56,6 @@ jobs:
           paths:
             - "~/.m2"
 
-  ancient:
-    <<: *defaults
-    steps:
-      - checkout
-
-      - restore_cache:
-          keys:
-            - v1-m2-{{ .Branch }}-{{ checksum "project.clj" }}
-
-      - run: lein ancient :all
-
-      - save_cache:
-          key: v1-m2-{{ .Branch }}-{{ checksum "project.clj" }}
-          paths:
-            - "~/.m2"
-
 workflows:
   version: 2
   build_and_test:
@@ -81,13 +65,3 @@ workflows:
       - test:
           requires:
             - build
-  monthly_deps_check:
-    jobs:
-      - ancient
-    triggers:
-      - schedule:
-          # At 11:43 on day-of-month 19
-          cron: "43 11 19 * *"
-          filters:
-            branches:
-              only: master

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,6 @@
                  [com.squareup.okio/okio-jvm "3.4.0"]
                  [com.segment.analytics.java/analytics "3.5.0"]]
   :profiles {:dev {:dependencies [[bond "0.2.6"]]}}
-  :plugins [[lein-ancient "0.6.15"]
-            [lein-codox "0.10.8"]]
+  :plugins [[lein-codox "0.10.8"]]
   :codox {:output-path "docs"
           :namespaces [circleci.analytics-clj.core]})


### PR DESCRIPTION
This seems less valuable now that we have Renovate to bump dependencies for us.

Proposed as a replacement for https://github.com/circleci/analytics-clj/pull/30