### PR TITLE
Flatten CI workflow & remove unnecessary CI caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,63 +13,32 @@ jobs:
       - checkout
       - run: clj-kondo --lint .
 
-  build:
+  check:
     <<: *defaults
     steps:
       - checkout
-
-      - restore_cache:
-          keys:
-            - v1-m2-{{ .Branch }}-{{ checksum "project.clj" }}
-
       - run: lein deps
-
       - run: lein check
-
-      - save_cache:
-          key: v1-m2-{{ .Branch }}-{{ checksum "project.clj" }}
-          paths:
-            - "~/.m2"
 
   docs:
     <<: *defaults
     steps:
       - checkout
-
-      - restore_cache:
-          keys:
-            - v1-m2-{{ .Branch }}-{{ checksum "project.clj" }}
-
+      - run: lein deps
       - run: lein codox
-
-      - save_cache:
-          key: v1-m2-{{ .Branch }}-{{ checksum "project.clj" }}
-          paths:
-            - "~/.m2"
 
   test:
     <<: *defaults
     steps:
       - checkout
-
-      - restore_cache:
-          keys:
-            - v1-m2-{{ .Branch }}-{{ checksum "project.clj" }}
-
+      - run: lein deps
       - run: lein test
-
-      - save_cache:
-          key: v1-m2-{{ .Branch }}-{{ checksum "project.clj" }}
-          paths:
-            - "~/.m2"
 
 workflows:
   version: 2
   build_and_test:
     jobs:
       - clj-kondo
-      - build
+      - check
       - docs
-      - test:
-          requires:
-            - build
+      - test


### PR DESCRIPTION
The CI cache is tied to as single branch, and is not very effective. It is my estimation that we don't build this often enough that the caching is worth the extra complexity in the config.

Flatten the workflow so the tests don't have to depend on the check. This means fewer CI roundtrips to find out that both check and test jobs fail.