### PR TITLE
Automate publishing of tagged releases to Clojars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,28 @@ jobs:
       - run: lein check
       - run: lein test
 
+  publish:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: lein deps
+      - run: lein deploy
+
 workflows:
   version: 2
-  build_and_test:
+  test_and_publish:
     jobs:
       - clj-kondo
       - docs
       - test
+      - publish:
+          context: clojars-publish
+          requires:
+            - clj-kondo
+            - docs
+            - test
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Version NEXT
+Version 0.10.0 (March 22, 2024)
 ================================
 
 * [#25](https://github.com/circleci/analytics-clj/pull/25): Update CODEOWNERS with more relevant team

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ For full documentation on the Segment.io 2.x Java client, see [analytics-java](h
 
 ## Installation
 
-`[circleci/analytics-clj "0.8.2"]`
+`[circleci/analytics-clj "<VERSION>"]`
+
+To find the most recent published version, see https://clojars.org/circleci/analytics-clj
 
 ## Usage
 
@@ -101,6 +103,16 @@ We provided a top level `enqueue` function to allow you to do the following:
                          (.userId "user-id")
                          (.properties {"company" "Acme Inc."})))
 ```
+
+
+## Releasing
+
+New git tags are automatically published to [clojars](https://clojars.org/circleci/bond).
+
+The following should be updated on the main/master branch before tagging:
+
+- `project.clj` - version
+- `CHANGELOG.md` - summary of changes
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject circleci/analytics-clj "0.8.2"
+(defproject circleci/analytics-clj "0.10.0"
   :description "Idiomatic Clojure wrapper for the Segment.io 2.x Java client"
   :url "https://github.com/circleci/analytics-clj"
   :license {:name "Eclipse Public License"
@@ -9,4 +9,13 @@
   :profiles {:dev {:dependencies [[bond "0.2.6"]]}}
   :plugins [[lein-codox "0.10.8"]]
   :codox {:output-path "docs"
-          :namespaces [circleci.analytics-clj.core]})
+          :namespaces [circleci.analytics-clj.core]}
+
+  :repositories [["releases" {:url "https://clojars.org/repo"
+                              :username :env/clojars_username
+                              :password :env/clojars_token
+                              :sign-releases false}]
+                 ["snapshots" {:url "https://clojars.org/repo"
+                               :username :env/clojars_username
+                               :password :env/clojars_token
+                               :sign-releases false}]])


### PR DESCRIPTION
So that we don't need to find credentials and remember how to release changes manually. Git tags are used to trigger publishing so that we don't re-publish over existing versions every time we merge to master. It also means that we're more likely to remember to tag and don't need to add any logic or credentials for the workflow to create tags.

An alternative would have been to use the build number as a patch version, but it's unwieldy for both for users and for us to maintain the versions in `README.md` and `CHANGELOG.md`.

I cribbed liberally from https://github.com/circleci/bond/pull/52 for this.

----

Once this is merged I intend to use it to address https://github.com/circleci/analytics-clj/issues/18 and https://github.com/circleci/analytics-clj/issues/16