### PR TITLE
All jobs required by the deploy job must also run for tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,18 @@ workflows:
   version: 2
   test_and_publish:
     jobs:
-      - clj-kondo
-      - docs
-      - test
+      - clj-kondo:
+          filters:
+            tags:
+              only: /.*/
+      - docs:
+          filters:
+            tags:
+              only: /.*/
+      - test:
+          filters:
+            tags:
+              only: /.*/
       - publish:
           context: clojars-publish
           requires:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Version 0.10.0 (March 22, 2024)
+Version 0.10.1 (March 22, 2024)
 ================================
 
 * [#25](https://github.com/circleci/analytics-clj/pull/25): Update CODEOWNERS with more relevant team
@@ -9,6 +9,12 @@ Version 0.10.0 (March 22, 2024)
 * [#31](https://github.com/circleci/analytics-clj/pull/31): Bump Clojure dependency to 1.11.2
 * [#27](https://github.com/circleci/analytics-clj/pull/27): Bump transitive dependency okio-java and move it to managed-dependencies
 * [#34](https://github.com/circleci/analytics-clj/pull/34): Bump `com.segment.analytics.java` dependency
+
+Version 0.10.0 (March 22, 2024)
+================================
+
+Not pushed to Clojars because of a bug in the new automatic publishing CI job.
+
 
 Version 0.8.2 (October 3, 2023)
 ================================


### PR DESCRIPTION
It is not sufficient to make the publish job run for tags, we need to make all its required jobs run for tags too. Otherwise we get this situation: https://app.circleci.com/pipelines/github/circleci/analytics-clj