### PR TITLE
Ensure that CIRCLE_TAG and the version in project.clj agrees

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,19 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - run: |
+          # Grab the numerical version of the tag
+          tag_version=${CIRCLE_TAG#v}
+
+          # Extract the version from the project.clj
+          project_version=$(awk 'NR==1 {print $3}' project.clj | sed -e 's/"//g')
+
+          # Fail if the tags do not match
+          test ${tag_version} = ${project_version} || exit 1
+
+          # Fail if the tag version is not in CHANGELOG
+          grep "^Version" CHANGELOG.md | grep "${tag_version}" || exit 1
+
       - run: lein deps
       - run: lein deploy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Version 0.10.2 (March 22, 2024)
+================================
+
+Code identical to 0.10.0 or 0.10.1, this is just a fix to the automatic release workflow.
+
 Version 0.10.1 (March 22, 2024)
 ================================
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject circleci/analytics-clj "0.10.0"
+(defproject circleci/analytics-clj "0.10.2"
   :description "Idiomatic Clojure wrapper for the Segment.io 2.x Java client"
   :url "https://github.com/circleci/analytics-clj"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
Also verify there is a CHANGELOG entry for that version before it will publish to Clojars.

The motivation for this change is that when I pushed the [tag 0.10.1](https://app.circleci.com/pipelines/github/circleci/analytics-clj/134/workflows/a35aa614-ea33-4df2-88b8-98c110e1a5d7), I ended up publishing version 0.10.0 to Clojars, because I had forgotten to update project.clj first.